### PR TITLE
Update INIFile.cs

### DIFF
--- a/source/INI/PeanutButter.INI/INIFile.cs
+++ b/source/INI/PeanutButter.INI/INIFile.cs
@@ -386,6 +386,8 @@ namespace PeanutButter.INIFile
         private bool HaveUnmatchedQuotesIn(IEnumerable<string> parts)
         {
             var joined = string.Join(";", parts);
+                if (!joined.EndsWith('"'))
+                    return true;
             var quoted = joined.Count(c => c == '"');
             return quoted % 2 != 0;
         }


### PR DESCRIPTION
Fix HaveUnmatchedQuotesIn to continue parsing data portion of ini entry line when the data doesn't have a double quote at the end (even if the data portion has even number of double quotes.